### PR TITLE
Release 0.5.0

### DIFF
--- a/expect/src/main/kotlin/com.nhaarman.expect/Matcher.kt
+++ b/expect/src/main/kotlin/com.nhaarman.expect/Matcher.kt
@@ -22,7 +22,7 @@ fun <T : Any> expect(actual: T?): Matcher<T> {
 
 open class Matcher<T : Any>(val actual: T?) {
 
-    fun toBe(expected: T, reason: () -> Any = { "" }) {
+    fun toBeReferentially(expected: T, reason: () -> Any = { "" }) {
         if (actual !== expected) {
             fail (reason) {
                 expected(actual) { to("be") { expected } }
@@ -30,7 +30,7 @@ open class Matcher<T : Any>(val actual: T?) {
         }
     }
 
-    fun toNotBe(expected: T, reason: () -> Any = { "" }) {
+    fun toNotBeReferentially(expected: T, reason: () -> Any = { "" }) {
         if (actual === expected) {
             fail(reason) {
                 expected(actual) { to("not be") { expected } }
@@ -38,7 +38,7 @@ open class Matcher<T : Any>(val actual: T?) {
         }
     }
 
-    open fun toBeEqualTo(expected: T, reason: () -> Any = { "" }) {
+    open fun toBe(expected: T, reason: () -> Any = { "" }) {
         if (actual != expected ) {
             fail (reason) {
                 expected(actual) { to("be equal to", expected) }

--- a/expect/src/test/kotlin/com/nhaarman/expect/MatcherTest.kt
+++ b/expect/src/test/kotlin/com/nhaarman/expect/MatcherTest.kt
@@ -24,7 +24,7 @@ class MatcherTest {
     fun example_toBe() {
         val a = Any()
 
-        expect(a).toBe(a)
+        expect(a).toBeReferentially(a)
     }
 
     @Test
@@ -32,7 +32,7 @@ class MatcherTest {
         val actual = Data(1)
         val expected = Data(1)
 
-        expect(actual).toBeEqualTo(expected)
+        expect(actual).toBe(expected)
     }
 
     @Test
@@ -49,7 +49,7 @@ class MatcherTest {
         val matcher = Matcher(a)
 
         /* When */
-        matcher.toBe(a)
+        matcher.toBeReferentially(a)
 
         /* Then */
         awesome()
@@ -65,7 +65,7 @@ class MatcherTest {
         /* Then */
         expectErrorWithMessage("to be") when_ {
 
-            matcher.toBe(expected)
+            matcher.toBeReferentially(expected)
         }
     }
 
@@ -77,7 +77,7 @@ class MatcherTest {
 
         /* Then */
         expectErrorWithMessage("to not be") when_ {
-            matcher.toNotBe(a)
+            matcher.toNotBeReferentially(a)
         }
     }
 
@@ -89,7 +89,7 @@ class MatcherTest {
         val matcher = Matcher(actual)
 
         /* Then */
-        matcher.toNotBe(expected)
+        matcher.toNotBeReferentially(expected)
 
         /* Then */
         awesome()
@@ -102,7 +102,7 @@ class MatcherTest {
         val matcher = Matcher(data)
 
         /* When */
-        matcher.toBeEqualTo(data)
+        matcher.toBe(data)
 
         /* Then */
         awesome()
@@ -116,7 +116,7 @@ class MatcherTest {
         val matcher = Matcher(first)
 
         /* When */
-        matcher.toBeEqualTo(second)
+        matcher.toBe(second)
 
         /* Then */
         awesome()
@@ -132,7 +132,7 @@ class MatcherTest {
         /* Then */
         expectErrorWithMessage("to be equal to").when_ {
 
-            matcher.toBeEqualTo(second)
+            matcher.toBe(second)
         }
     }
 
@@ -146,7 +146,7 @@ class MatcherTest {
         /* Then */
         expectErrorWithMessage("to be equal to").when_ {
 
-            matcher.toBeEqualTo(second)
+            matcher.toBe(second)
         }
     }
 
@@ -158,7 +158,7 @@ class MatcherTest {
         /* Then */
         expectErrorWithMessage("to be equal to").when_ {
 
-            matcher.toBeEqualTo(1)
+            matcher.toBe(1)
         }
     }
 

--- a/expect/src/test/kotlin/com/nhaarman/expect/NumberMatcherTest.kt
+++ b/expect/src/test/kotlin/com/nhaarman/expect/NumberMatcherTest.kt
@@ -22,7 +22,7 @@ class NumberMatcherTest {
 
     @Test
     fun example_double_toBeEqualTo() {
-        expect(1.0).toBeEqualTo(1.0)
+        expect(1.0).toBe(1.0)
     }
 
     @Test
@@ -42,7 +42,7 @@ class NumberMatcherTest {
 
     @Test
     fun example_float_toBeEqualTo() {
-        expect(1.0f).toBeEqualTo(1.0f)
+        expect(1.0f).toBe(1.0f)
     }
 
     @Test
@@ -57,7 +57,7 @@ class NumberMatcherTest {
 
     @Test
     fun example_long_toBeEqualTo() {
-        expect(1L).toBeEqualTo(1L)
+        expect(1L).toBe(1L)
     }
 
     @Test
@@ -72,7 +72,7 @@ class NumberMatcherTest {
 
     @Test
     fun example_int_toBeEqualTo() {
-        expect(1).toBeEqualTo(1)
+        expect(1).toBe(1)
     }
 
     @Test
@@ -89,7 +89,7 @@ class NumberMatcherTest {
     fun example_short_toBeEqualTo() {
         val actual: Short = 1
         val expected: Short = 1
-        expect(actual).toBeEqualTo(expected)
+        expect(actual).toBe(expected)
     }
 
     @Test
@@ -110,7 +110,7 @@ class NumberMatcherTest {
     fun example_byte_toBeEqualTo() {
         val actual: Byte = 1
         val expected: Byte = 1
-        expect(actual).toBeEqualTo(expected)
+        expect(actual).toBe(expected)
     }
 
     @Test
@@ -133,7 +133,7 @@ class NumberMatcherTest {
         val matcher = NumberMatcher(1.0)
 
         /* When */
-        matcher.toBeEqualTo(1.0)
+        matcher.toBe(1.0)
 
         /* Then */
         awesome()
@@ -147,7 +147,7 @@ class NumberMatcherTest {
         /* Then */
         expectErrorWithMessage("to be equal to").on {
 
-            matcher.toBeEqualTo(2.0)
+            matcher.toBe(2.0)
         }
     }
 

--- a/expect/src/test/kotlin/com/nhaarman/expect/StringMatcherTest.kt
+++ b/expect/src/test/kotlin/com/nhaarman/expect/StringMatcherTest.kt
@@ -36,7 +36,7 @@ class StringMatcherTest {
         val matcher = StringMatcher(actual)
 
         /* When */
-        matcher.toBeEqualTo(expected)
+        matcher.toBe(expected)
 
         /* Then */
         awesome()
@@ -52,7 +52,7 @@ class StringMatcherTest {
         /* Then */
         expectErrorWithMessage("to be equal to").when_ {
 
-            matcher.toBeEqualTo(expected)
+            matcher.toBe(expected)
         }
     }
 


### PR DESCRIPTION
It is pretty annoying to have to write `toBeEqualTo` when this is the option most likely to be used most of the times.

Important:

`toBe` ==> `toBeReferentially`
`toBeEqualTo` ==> `toBe`
