### PR TITLE
Document the existing matchers that are available

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,53 @@ class MyTypeMatcher(actual: MyType?) : Matcher<MyType>(actual) {
 }
 ```
 
+## Available Matchers
+
+### Generic Matchers
+
+expect(actual).toBe(object)
+expect(actual).toBeTheSameAs(object)
+expect(actual).toNotBeTheSameAs(object)
+expect(actual).toBeNull()
+expect(actual).toNotBeNull()
+expect(actual).toBeInstanceOf<Type>()
+
+### Boolean Matchers
+
+expect(actual).toHold()
+expect(actual).notToHold()
+
+### Error Matchers
+
+expectErrorWithMessage(message).when_ { <something throws> }
+expectErrorWithMessage(message).on { <something throws> }
+
+### List Matchers
+
+expect(actual).toBeEmpty()
+expect(actual).toContain(object)
+expect(actual).toHaveSize(size)
+
+### Number Matchers
+
+expect(actual).toBe(number)
+expect(actual).toBeSmallerThan(number)
+expect(actual).toBeGreaterThan(number)
+expect(actual).toBeIn(number range)
+
+### String Matchers
+
+expect(actual).toBe(string)
+expect(actual).toContain(string)
+
+### Observer Matchers
+
+expect(observer).toHaveNoValues()
+expect(observer).toHaveValueCount(number)
+expect(observer).toHaveValues(value[, value, ...])
+expect(observer).toBeCompleted()
+expect(observer).toHaveError(exception)
+
 ## Setup
 
 Expect.kt is hosted on Maven Central.

--- a/README.md
+++ b/README.md
@@ -79,48 +79,62 @@ class MyTypeMatcher(actual: MyType?) : Matcher<MyType>(actual) {
 
 ### Generic Matchers
 
+```kt
 expect(actual).toBe(object)
 expect(actual).toBeTheSameAs(object)
 expect(actual).toNotBeTheSameAs(object)
 expect(actual).toBeNull()
 expect(actual).toNotBeNull()
 expect(actual).toBeInstanceOf<Type>()
+```
 
 ### Boolean Matchers
 
+```kt
 expect(actual).toHold()
 expect(actual).notToHold()
+```
 
 ### Error Matchers
 
+```kt
 expectErrorWithMessage(message).when_ { <something throws> }
 expectErrorWithMessage(message).on { <something throws> }
+```
 
 ### List Matchers
 
+```kt
 expect(actual).toBeEmpty()
 expect(actual).toContain(object)
 expect(actual).toHaveSize(size)
+```
 
 ### Number Matchers
 
+```kt
 expect(actual).toBe(number)
 expect(actual).toBeSmallerThan(number)
 expect(actual).toBeGreaterThan(number)
 expect(actual).toBeIn(number range)
+```
 
 ### String Matchers
 
+```kt
 expect(actual).toBe(string)
 expect(actual).toContain(string)
+```
 
 ### Observer Matchers
 
+```kt
 expect(observer).toHaveNoValues()
 expect(observer).toHaveValueCount(number)
 expect(observer).toHaveValues(value[, value, ...])
 expect(observer).toBeCompleted()
 expect(observer).toHaveError(exception)
+```
 
 ## Setup
 


### PR DESCRIPTION
Document the existing set of matchers that are available
based on the current unit tests.